### PR TITLE
Filtering for file-based XSS & mobile support

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,108 +1,90 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <style>
-body {
-  color: white;
-  background-color: #181a1b;
-  font-family: monospace;
-  overflow-wrap: break-word;
-}
+	<head>
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+		<style>
+			body {
+				color: white;
+				background-color: #181a1b;
+				font-family: monospace;
+				overflow-wrap: break-word;
+			}
 
-canvas {
-  width: 60%;
-}
+			h1 {
+				text-align: center;
+			}
+		</style>
+	</head>
 
-h1 {
-  text-align: center;
-  margin-bottom: 0;
-}
+	<body data-theme="dark">
+		<div class="container" id="drop">
+			<header>
+				<h1>Image based Steganography</h1>
 
-input {
-  vertical-align: middle;
-}
+				<h3>About</h3>
+				<p>
+					DWT-DCT method to hide messages inside an image. Implementation based off of this paper
+					<a href="https://pdfs.semanticscholar.org/1c47/f281c00cffad4e30deff48a922553cb04d17.pdf">
+						Ali Al-Haj, "Combined DWT-DCT Digital Image Watermarking", September 2007
+					</a>.
 
-html, body {
-  padding: 0;
-  margin: 0;
-}
+					The main goal of this was to encode a message in an image which was
+					file format independent, and somewhat compression resistant such that
+					it could be sent over the internet trivially, though the end result is
+					fairly inconsistent. My main test for this was to paste it into discord
+					then decoding the compressed preview version.
 
-textarea, button, input, canvas, img {
-  background-color: #282a2b;
-  border-color: #383a3b;
-  color: white;
-}
+					This is somewhat successful when the original image was already small
+					such that the discord preview version was relatively the same
+					resolution. Also, images with uniform backgrounds may also be clearer.
 
-/* unvisited link */
-a:link {
-  color: #0099ff;
-}
+					I was thinking of adding encryption for the message, but I realise now
+					that any errors might mess up the entire encryption process. Instead,
+					knowing the seed of the noise pattern the message is embedded in can be
+					used a pseudo decryption key for secret messages.
+				</p>
+			</header>
 
-/* visited link */
-a:visited {
-  color: #00ffff;
-}
+			<h3>Uploader</h3>
 
-#drop {
-  padding-left: 20px;
-  width: 95vw;
-  height: 95vh;
-}
-    </style>
-  </head>
-  <body>
-    <div id="drop">
-      <h1>Image based Steganography</h1>
-      <p>DWT-DCT method to hide messages inside an image. Implementation based off of this paper
-        <a href="https://pdfs.semanticscholar.org/1c47/f281c00cffad4e30deff48a922553cb04d17.pdf">
-          Ali Al-Haj, "Combined DWT-DCT Digital Image Watermarking", September 2007
-        </a>.
-        The main goal of this was to encode a message in an image which was
-        file format independent, and somewhat compression resistant such that
-        it could be sent over the internet trivially, though the end result is
-        fairly inconsistent. My main test for this was to paste it into discord
-        then decoding the compressed preview version.
-        
-        This is somewhat successful when the original image was already small
-        such that the discord preview version was relatively the same
-        resolution. Also, images with uniform backgrounds may also be clearer.
-        
-        I was thinking of adding encryption for the message, but I realise now
-        that any errors might mess up the entire encryption process. Instead,
-        knowing the seed of the noise pattern the message is embedded in can be
-        used a pseudo decryption key for secret messages.
-      </p>
-      <div style="display: flex;">
-        <div style="padding-right: 20px">
-          <label for="img">Select, drop or paste image:</label>
-          <input type="file" id="source" name="img" accept="image/*">
-          <br>
-          <textarea placeholder="Enter text to encode here" cols=90 rows=15 id="text"></textarea>
-          <br>
-          <p id="count"></p>
-          <button id="encode">Encode</button>
-          <button id="decode">Decode</button>
-          <button id="save">Save</button>
-          <br>
-          Intensity: <input type="range" id="gain" min="8" max="32" value="12">
-          Seed (key): <input type="text" id="seed" value="default">
-          <br>
-          Note:
-          <ul>
-            <li>Recipient will need the same message seed to decode (insecure pseudo-encryption).</li>
-            <li>After encoding, you can right click and copy the image to clipboard.</li>
-          </ul>
-        </div>
-        <div>
-          <p id="info">WIDTHxHEIGHT</p>
-          <img id="target" hidden></img>
-          <canvas id="preview" width="600" height="600" style="border: 1px solid;"></canvas>
-        </div>
-      </div>
-      <p id="output"></p>
-      <canvas width="512" height="512" style="border: 1px solid" id="buffer" hidden></canvas>
-      <img id="display"></img>
-      <script src="main.js" type="module"></script>
-    </div>
-  </body>
+			<div class="grid">
+				<div>
+					<label for="img">Select, drop or paste image:</label>
+					<input type="file" id="source" name="img" accept="image/*">
+					<textarea placeholder="Enter text to encode here" rows="10" id="text"></textarea>
+
+					<p id="count"></p>
+					<button id="encode">Encode</button>
+					<button id="decode">Decode</button>
+					<button id="save">Save</button>
+				</div>
+
+				<div>
+					<p id="info">WIDTHxHEIGHT</p>
+					<img id="target" hidden></img>
+
+					<canvas id="preview" style="border: 1px solid rgba(255, 255, 255, 0.3);"></canvas>
+				</div>
+			</div>
+			
+			<br>
+			Intensity: <input type="range" id="gain" min="8" max="32" value="12">
+			Seed (key): <input type="text" id="seed" value="default">
+			<br>
+
+			Note:
+
+			<ul>
+				<li>Recipient will need the same message seed to decode (insecure pseudo-encryption).</li>
+				<li>After encoding, you can right click and copy the image to clipboard.</li>
+			</ul>
+
+			<h3>Output</h3>
+			<p id="output"></p>
+
+			<canvas width="512" height="512" style="border: 1px solid" id="buffer" hidden></canvas>
+			<img id="display"></img>
+			<script src="main.js" type="module"></script>
+		</div>
+	</body>
 </html>

--- a/main.js
+++ b/main.js
@@ -365,10 +365,48 @@ function changeTarget(src) {
   target.src = src;
   target.onload = () => {
     info.innerHTML = `${target.width}x${target.height}`;
-    preview.width = target.width / target.height * 512;
-    preview.getContext("2d").drawImage(target, 0, 0, preview.width, preview.height);
+
+    // Modified to retain aspect ratio of image while remaining in the bounds of the parent div
+    // Good for large images, or images which weird aspect ratios. Downsides are lossless quality on preview
+    // Possibly could be fixed by changing canvas filtering / .width .height attributes on canvas element itself?
+    // - dceit.
+
+    const newWidth = target.width;
+    const newHeight = target.height;
+
+    const parentWidth = preview.parentElement.offsetWidth;
+    const parentHeight = preview.parentElement.offsetHeight;
+
+    const aspectRatio = newWidth / newHeight;
+
+    let displayWidth, displayHeight;
+
+    if (newWidth > parentWidth || newHeight > parentHeight) {
+      if (parentWidth / aspectRatio <= parentHeight) {
+        displayWidth = parentWidth;
+        displayHeight = parentWidth / aspectRatio;
+      } else {
+        displayHeight = parentHeight;
+        displayWidth = parentHeight * aspectRatio;
+      }
+    } else {
+      displayWidth = newWidth;
+      displayHeight = newHeight;
+    }
+
+    const previewWidthPercentage = (displayWidth / parentWidth) * 100;
+    const previewHeightPercentage = (displayHeight / parentHeight) * 100;
+
+    preview.style.width = `${Math.min(previewWidthPercentage, 100)}%`;
+    preview.style.height = `${Math.min(previewHeightPercentage, 100)}%`;
+
+    const ctx = preview.getContext("2d");
+    ctx.clearRect(0, 0, preview.width, preview.height); // Clear the canvas
+    ctx.drawImage(target, 0, 0, preview.width, preview.height);
   };
 }
+
+
 
 imageUpload.addEventListener("change", (e) => {
   changeTarget(window.URL.createObjectURL(imageUpload.files[0]));

--- a/main.js
+++ b/main.js
@@ -93,7 +93,7 @@ function decodeImage(image) {
   const binaryString = decodedMessage.join("");
   const asciiString = convertASCII(binaryString);
   
-  output.innerHTML = "Decoded ASCII: " + asciiString;
+  output.innerText = "Decoded ASCII: " + asciiString;
   // output.innerHTML += "<br>";
   // output.innerHTML += "Binary Decoding: " + binaryString;
 }


### PR DESCRIPTION
A user was previously able to encode the message `<img src=x onerror=alert(1)>` in-order to get JavaScript execution when a user decodes an image. This could be used by a threat-actor to identify a user using your tool, or execute more malicious payloads to steal sensitive information.

`innerHTML` should not be used on user-supplied strings.
https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/XSS

It was unintended to be included in this PR, but this also includes a rework of the user interface using PicoCSS.
Here is an image of what the new UI may look like. I implemented this for the added mobile support.

![image](https://github.com/user-attachments/assets/34a63233-410a-4da7-9ae4-f2878c70f285)
